### PR TITLE
Fixing wrong noverbose summary transformer war test path

### DIFF
--- a/src/test/java/com/aequilibrium/transformers/controller/TransformerWarControllerTest.java
+++ b/src/test/java/com/aequilibrium/transformers/controller/TransformerWarControllerTest.java
@@ -103,7 +103,7 @@ public class TransformerWarControllerTest {
 			      .andExpect(jsonPath("$.details").isNotEmpty());
 		
 		mockMvc.perform( MockMvcRequestBuilders
-			      .get("/api/transformers/war/noverbose")
+			      .get("/api/transformers/war/noVerbose")
 			      .contentType(MediaType.APPLICATION_JSON)
 			      .accept(MediaType.APPLICATION_JSON))
 			      .andExpect(status().isOk())


### PR DESCRIPTION
Just fixing the path from /api/transformers/war/noverbose, to /api/transformers/war/noVerbose